### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - run: make build
+      - uses: softprops/action-gh-release@v1
+        with:
+          files: bin/github-notify


### PR DESCRIPTION
## Summary
- build Go binary using `make build`
- upload `bin/github-notify` to a GitHub release when tags are pushed

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6883205e70d48328a57615dbdb070807